### PR TITLE
Add LLVM file types and extensions as well as extensions used by LLVM

### DIFF
--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -104,7 +104,7 @@ programming:
     crystal: [.cr]
     csharp: [.cs, .csx]
     css: [css]
-    cxx: [.c, .cpp, .cc, .cp, .cxx, .c++, .h, .hh, .hpp, .hxx, .h++, .inl, .ipp]
+    cxx: [.c, .cpp, .cc, .cp, .cxx, .c++, .h, .hh, .hpp, .hxx, .h++, .inc, .inl, .ipp, .def]
     d: [.d, .di]
     dart: [.dart]
     diff: [.diff, .patch]
@@ -123,6 +123,7 @@ programming:
     kotlin: [.kt, .kts]
     latex: [.tex, .ltx]
     less: [.less]
+    llvm: [.ll, .mir]
     lisp: [.lisp, .el]
     lua: [.lua]
     mathematica: [.nb]
@@ -142,6 +143,7 @@ programming:
     shell: [.sh, .bash, .zsh, .fish]
     sql: [.sql]
     swift: [.swift]
+    tablegen: [.td]
     tcl: [.tcl]
     typescript: [.ts, .tsx]
     viml: [.vim]
@@ -376,6 +378,8 @@ unimportant:
       - .sty
       - .synctex.gz
       - .toc
+    llvm:
+      - .bc
 
   other:
     - "~"


### PR DESCRIPTION
in various places.

This includes the LLVM textual IR (.ll), generated bitcode files (.bc),
a custom language used in LLVM's implementation called "TableGen" (.td),
and C++ extensions used for generated code and X-macro files (.def and
.inc).

Bitcode files are treated similarly to object files, although that is
a bit odd. They are somewhere between archives and object files in terms
of utility, but they most often show up as intermediate files. When
being packaged and used, they are more commonly placed into an archive,
so this seems the least confusing scheme to me.