### PR TITLE
Add new core filetypes for STICKY/OTHER_WRITABLE/STICKY_OTHER_WRITABL…

### DIFF
--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -15,6 +15,11 @@ core:
 
   normal_text: [$no]
 
+  sticky: [$st]
+
+  other_writable: [$ow]
+  sticky_other_writable: [$tw]
+
 text:
   special:
     - CONTRIBUTORS

--- a/themes/ayu.yml
+++ b/themes/ayu.yml
@@ -52,6 +52,15 @@ core:
   normal_text:
     {}
 
+  sticky:
+    {}
+
+  sticky_other_writable:
+    {}
+
+  other_writable:
+    {}
+
 text:
   special:
     foreground: black

--- a/themes/jellybeans.yml
+++ b/themes/jellybeans.yml
@@ -59,6 +59,15 @@ core:
   normal_text:
     {}
 
+  sticky:
+    {}
+
+  sticky_other_writable:
+    {}
+
+  other_writable:
+    {}
+
 text:
   special:
     foreground: brighter_green

--- a/themes/molokai.yml
+++ b/themes/molokai.yml
@@ -52,8 +52,16 @@ core:
     foreground: cyan
     background: darkgray
 
-
   normal_text:
+    {}
+
+  sticky:
+    {}
+
+  sticky_other_writable:
+    {}
+
+  other_writable:
     {}
 
 text:

--- a/themes/snazzy.yml
+++ b/themes/snazzy.yml
@@ -61,6 +61,15 @@ core:
   normal_text:
     {}
 
+  other_writable:
+    {}
+
+  sticky:
+    {}
+
+  sticky_other_writable:
+    {}
+
 text:
   special:
     foreground: background_color

--- a/themes/solarized-dark.yml
+++ b/themes/solarized-dark.yml
@@ -66,6 +66,15 @@ core:
   normal_text:
     foreground: base0
 
+  other_writable:
+    {}
+
+  sticky:
+    {}
+
+  sticky_other_writable:
+    {}
+
 text:
   special:
     foreground: base0

--- a/themes/solarized-light.yml
+++ b/themes/solarized-light.yml
@@ -66,6 +66,15 @@ core:
   normal_text:
     foreground: base00
 
+  other_writable:
+    {}
+
+  sticky:
+    {}
+
+  sticky_other_writable:
+    {}
+
 text:
   special:
     foreground: base00


### PR DESCRIPTION
These flags are set inside of WSL on directories mapped in from the Windows host OS
and default to an ugly/unreadable green background for numerous files in Ubuntu and
possibly other WSL supported distributions.

Added core filetype definitions for these file types and updated the themes to add a
blank LS_COLORS entry for each type which alleviates the theme breaking default
background color for WSL.

Please let me know if you need anything changed/tested to incorporate this change. Thank you!