### PR TITLE
Fix INSTALL.txt

### DIFF
--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -28,7 +28,7 @@ text:
     - CONTRIBUTORS.txt
     - INSTALL
     - INSTALL.md
-    - INSTALL.md.txt
+    - INSTALL.txt
     - README
     - README.md
     - README.txt


### PR DESCRIPTION
Fixed a typo in `config/filetypes.yml`, changing `INSTALL.md.txt` to `INSTALL.txt`.