### PR TITLE
Add more media file types

### DIFF
--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -228,6 +228,7 @@ programming:
 media:
   image:
     - .bmp
+    - .eps
     - .gif
     - .ico
     - .jpeg
@@ -236,13 +237,16 @@ media:
     - .pgm
     - .png
     - .ppm
+    - .psd
     - .svg
     - .tif
+    - .tiff
     - .xcf
 
   audio:
     - .aif
     - .flac
+    - .m4a
     - .mid
     - .mp3
     - .ogg


### PR DESCRIPTION
Image filetypes:
Added .eps (Encapsulated PostScript) - https://fileinfo.com/extension/eps
Added .psd (Adobe Photoshop Document) - https://fileinfo.com/extension/psd
Added .tiff (alternative extension to Tagged Image File Format) - https://fileinfo.com/extension/tiff

Audio filetypes:
Added .m4a (MPEG-4 Audio File) - https://fileinfo.com/extension/m4a