### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ You can install `vivid` from [the official package repository](https://www.archl
 pacman -S vivid
 ```
 
-### On other distrubutions
+### On other distributions
 
 Check out the [release page](https://github.com/sharkdp/vivid/releases) for binary builds.
 
-Make sure that you install the contents of the `share/vivid` folder at
-`/usr/share/vivid` or at `$HOME/.config/vivid`.
+Make sure that you install the contents of the `share/vivid` folder to
+`/usr/share/vivid` or `$HOME/.config/vivid` on POSIX systems and `%APPDATA%\vivid` on Windows systems.
 
 ### Via cargo
 
@@ -73,7 +73,7 @@ If you have Rust 1.31 or higher, you can install `vivid` from source via `cargo`
 cargo install vivid
 ```
 
-Make sure that you install the assets (database and themes) separately. See above for instructions.
+Make sure to install the assets (database: `$srcdir/config/filetypes.yml` and themes: `$srcdir/themes`) to one of the locations listed in the ["On other distributions" section](#on-other-distributions).
 
 ## License
 


### PR DESCRIPTION
Windows uses a different config location than the XDG standard, so I updated the README to reflect this.
Other minor edits are fixing a typo in the header and linking to that header instead of relying on "above" (in case the text moves around later).
And expanding on what files need to be copied (so you don't have to download the binary release and check `/share` or read the source code to see. Just copy/link them from the source you're building from.)

I figured proof of this would be nice to have, so I'm uploading a screencast that shows it works on my machine in this location and with tools that use `LS_COLORS`: https://youtu.be/kKN010Zja7g
(Unfortunately though, my ISP is having an outage and I'm tethered to mobile at a blazing 10kbps right now, so it won't be published for at least 3 hours from now...🙃)