### PR TITLE
Subcommand to list out available themes

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,7 @@ pub enum VividError {
     EmptyThemeFile,
     CouldNotFindStyleFor(String),
     UnknownColor(String),
+    InvalidFileName(String),
 }
 
 impl Display for VividError {
@@ -45,6 +46,9 @@ impl Display for VividError {
                 write!(fmt, "Could not find style for category '{}'", category)
             }
             VividError::UnknownColor(color) => write!(fmt, "Unknown color '{}'", color),
+            VividError::InvalidFileName(file_name) => {
+                write!(fmt, "Invalid file name '{}'", file_name)
+            }
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,3 +22,7 @@ pub fn transpose<T, E>(
 pub fn get_first_existing_path<'a>(paths: &[&'a Path]) -> Option<&'a Path> {
     paths.iter().find(|p| Path::exists(*p)).copied()
 }
+
+pub fn get_all_existing_paths<'a>(paths: &[&'a Path]) -> Vec<&'a Path> {
+    paths.iter().cloned().filter(|p| Path::exists(*p)).collect()
+}


### PR DESCRIPTION
Possibly resolves #46 (not entirely sure what the ask is), or at the very least hopefully adds some useful functionality. 

The goal is to display to users which themes are available to use, so that they have an idea of what can be run into `preview` or `generate`.

Output

```
> ./target/debug/vivid themes
ayu
jellybeans
molokai
snazzy
solarized-light
solarized-dark
```