### PR TITLE
Add Opus and WavPack audio extensions

### DIFF
--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -250,8 +250,10 @@ media:
     - .mid
     - .mp3
     - .ogg
+    - .opus
     - .wav
     - .wma
+    - .wv
 
   video:
     - .avi


### PR DESCRIPTION
Add extensions for [Opus ](https://en.wikipedia.org/wiki/Opus_(audio_format)) and [WavPack](https://en.wikipedia.org/wiki/WavPack) audio formats.