### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM rust:1.69-bullseye as rust-build-stage
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+COPY Cargo.lock Cargo.toml ./
+COPY src src/
+COPY config config/
+COPY themes themes/
+RUN cargo build --release
+
+FROM gcr.io/distroless/cc-debian10
+USER 1001:1001
+
+WORKDIR /app
+COPY --from=rust-build-stage --chown=1001:1001 /build/target/release/vivid .
+
+ENTRYPOINT ["/app/vivid"]


### PR DESCRIPTION
This gives me an image about 18Mb.

```console
$ docker run vivid:latest --help
LS_COLORS manager with multiple themes

Usage: vivid [OPTIONS] <COMMAND>

Commands:
  generate  Generate a LS_COLORS expression
  preview   Preview a given theme
  themes    Prints list of available themes
  help      Print this message or the help of the given subcommand(s)

Options:
  -m, --color-mode <mode>  Type of ANSI colors to be used [default: 24-bit] [possible values: 8-bit,
                           24-bit]
  -d, --database <path>    Path to filetypes database (filetypes.yml)
  -h, --help               Print help
  -V, --version            Print version
```