### PR TITLE
Added multiple filetypes, explained in depth in the pull request

### DIFF
--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -173,7 +173,7 @@ programming:
     rust: [.rs]
     sass: [.sass, .scss]
     scala: [.scala, .sbt]
-    shell: [.sh, .bash, .bashrc, .bash_profile, .zsh, .fish]
+    shell: [.sh, .bash, , .nu, .bashrc, .bash_profile, .zsh, .fish]
     sql: [.sql]
     swift: [.swift]
     tablegen: [.td]

--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -53,6 +53,7 @@ text:
   licenses:
     - COPYING
     - COPYRIGHT
+    - LICENCE
     - LICENSE
     - LICENSE-APACHE
     - LICENSE-MIT

--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -43,6 +43,7 @@ text:
     - README
     - README.md
     - README.txt
+    - VERSION
 
   todo:
     - TODO

--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -34,9 +34,12 @@ text:
     - CONTRIBUTORS
     - CONTRIBUTORS.md
     - CONTRIBUTORS.txt
+    - FAQ
     - INSTALL
     - INSTALL.md
     - INSTALL.txt
+    - LEGACY
+    - NOTICE
     - README
     - README.md
     - README.txt
@@ -100,12 +103,15 @@ markup:
     - .xhtml
 
   other:
+    - ".1"
     - .csv
     - .markdown
     - .md
     - .mdown
+    - .info
     - .org
     - .rst
+    - .typ
     - .xml
 
 programming:
@@ -122,7 +128,7 @@ programming:
     crystal: [.cr]
     csharp: [.cs, .csx]
     css: [.css]
-    cxx: [.c, .cpp, .cc, .cp, .cxx, .c++, .h, .hh, .hpp, .hxx, .h++, .inc, .inl, .ipp, .def]
+    cxx: [.c, .cpp, .cc, .cp, .cxx, .c++, .h, .hh, .hpp, .hxx, .h++, .ino, .inc, .inl, .ipp, .def]
     d: [.d, .di]
     dart: [.dart]
     diff: [.diff, .patch]
@@ -206,6 +212,7 @@ programming:
       make:
         - Makefile
         - .make
+        - .mk
 
       automake:
         - Makefile.am
@@ -460,6 +467,7 @@ archives:
     - .arj
     - .bz
     - .bz2
+    - .db
     - .gz
     - .jar
     - .pkg
@@ -500,6 +508,7 @@ unimportant:
       - Makefile.in
     rust:
       - .rlib
+      - .rmeta
     python:
       - .pyc
       - .pyd
@@ -547,7 +556,11 @@ unimportant:
     - .orig
     - .pid
     - .swp
+    - .timestamp
     - .tmp
+    - stderr
+    - stdin
+    - stdout
     - bun.lockb
     - go.sum
     - package-lock.json


### PR DESCRIPTION
The additions are:

in text: special:
- FAQ (Frequently Asked Questions)
- LEGACY (information on legacy support or the like)
- NOTICE (important information that should be noticed)
- VERSION (version information)

in text: licenses:
- LICENCE (an alternative, but correct, spelling of LICENSE)

in markup: other:
- .1 (The format of man-pages on linux)
- .info (a GNU rich text format generated by GNU texinfo)
- .typ (source files for the typesetting program Typst)

in programming: source: cxx:
- .ino (source files for the Arduino platform, essentially extended C++)

in programming: source: shell:
- .nu (source files for the nu shell)

in programming: tooling: build:
- .mk (the same as .make)

in archives: other:
- .db (SQL, and possibly other, database files. bit unsure about the position for this one)

in unimportant: build_artifacts: rust:
- .rmeta (meta information about the crate in which it is found)

in unimportant: other:
- .timestamp (timestamp files, rarely used by actual humans)
- stderr (bit unsure about the position of these three, as calling them unimportant hardly seems true)
- stdin
- stdout