### PR TITLE
Add jsx filtype

### DIFF
--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -125,7 +125,7 @@ programming:
     haskell: [.hs]
     ipython: [.ipynb]
     java: [.java, .bsh]
-    javascript: [.js, .htc]
+    javascript: [.js, .jsx, .htc]
     julia: [.jl]
     kotlin: [.kt, .kts]
     latex: [.tex, .ltx]


### PR DESCRIPTION
Typescript already has the `.tsx` filetype. We were missing the `.jsx` filetype for javascript.