### PR TITLE
Allowed font_style to be an array

### DIFF
--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -111,6 +111,7 @@ markup:
 programming:
   source:
     actionscript: [.as]
+    ada: [.adb, .ads]
     applescript: [.applescript]
     asp: [.asa]
     awk: [.awk]
@@ -132,6 +133,7 @@ programming:
     go: [.go]
     graphviz: [.dot, .gv]
     groovy: [.groovy, .gvy, .gradle]
+    hack: [.hack]
     haskell: [.hs]
     ipython: [.ipynb]
     java: [.java, .bsh]
@@ -145,6 +147,8 @@ programming:
     lua: [.lua]
     mathematica: [.nb]
     matlab: [.matlab, .m, .mn]
+    mojo: [.mojo]
+    nim: [.nim, .nims, .nimble]
     ocaml: [.ml, .mli]
     pascal: [.pas, .p, .dpr]
     perl: [.pl, .pm, .pod, .t, .cgi]
@@ -155,6 +159,7 @@ programming:
     purescript: [.purs]
     python: [.py]
     r: [.r]
+    raku: [.raku]
     ruby: [.rb]
     rust: [.rs]
     sass: [.sass, .scss]
@@ -247,6 +252,7 @@ programming:
 
     continuous-integration:
       - appveyor.yml
+      - azure-pipelines.yml
       - .cirrus.yml
       - .gitlab-ci.yml
       - .travis.yml
@@ -263,16 +269,19 @@ media:
     - .jpg
     - .jxl
     - .pbm
+    - .pcx
     - .pgm
     - .png
     - .ppm
     - .psd
     - .qoi
     - .svg
+    - .tga
     - .tif
     - .tiff
     - .webp
     - .xcf
+    - .xpm
 
   audio:
     - .aif
@@ -298,6 +307,7 @@ media:
     - .mp4
     - .mpeg
     - .mpg
+    - .ogv
     - .rm
     - .swf
     - .vob
@@ -344,6 +354,7 @@ archives:
   packages:
     - .apk
     - .deb
+    - .msi
     - .rpm
     - .xbps
 

--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -150,12 +150,14 @@ programming:
     perl: [.pl, .pm, .pod, .t, .cgi]
     php: [.php]
     powershell: [.ps1, .psm1, .psd1]
+    prql: [.prql]
     puppet: [.pp, .epp]
     purescript: [.purs]
     python: [.py]
     r: [.r]
     ruby: [.rb]
     rust: [.rs]
+    sass: [.sass, .scss]
     scala: [.scala, .sbt]
     shell: [.sh, .bash, .bashrc, .bash_profile, .zsh, .fish]
     sql: [.sql]
@@ -165,6 +167,7 @@ programming:
     typescript: [.ts, .tsx]
     v: [.v, .vsh]
     viml: [.vim]
+    zig: [.zig]
 
   tooling:
     vcs:
@@ -184,6 +187,7 @@ programming:
         - .ignore
         - .fdignore
         - .rgignore
+        - .tfignore
 
     build:
       cmake:
@@ -253,14 +257,17 @@ media:
     - .bmp
     - .eps
     - .gif
+    - .heif
     - .ico
     - .jpeg
     - .jpg
+    - .jxl
     - .pbm
     - .pgm
     - .png
     - .ppm
     - .psd
+    - .qoi
     - .svg
     - .tif
     - .tiff
@@ -303,6 +310,7 @@ media:
     - .otf
     - .ttf
     - .woff
+    - .woff2
 
 office:
   document:
@@ -378,6 +386,7 @@ executable:
     - .so
     - .a
     - .dll
+    - .dylib
 
   linux:
     - .ko
@@ -442,5 +451,6 @@ unimportant:
     - .pid
     - .swp
     - .tmp
+    - bun.lockb
     - go.sum
     - package-lock.json

--- a/src/font_style.rs
+++ b/src/font_style.rs
@@ -50,15 +50,19 @@ impl FontStyle {
                 }
                 _ => panic!("font-style should be a string or an array of strings"),
             },
-            None => Self::default(),
+            None => Self(vec![0]),
         }
     }
 }
 
 impl Display for FontStyle {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        for style in &self.0 {
-            write!(f, "{};", style)?;
+        for (i, style) in self.0.iter().enumerate() {
+            if i + 1 == self.0.len() {
+                write!(f, "{}", style)?;
+            } else {
+                write!(f, "{};", style)?;
+            }
         }
         Ok(())
     }

--- a/src/font_style.rs
+++ b/src/font_style.rs
@@ -1,0 +1,65 @@
+use std::{
+    collections::HashMap,
+    fmt::{self, Display, Formatter},
+};
+
+use lazy_static::lazy_static;
+
+use yaml_rust::{yaml::Hash, Yaml};
+
+lazy_static! {
+    static ref ANSI_STYLES: HashMap<&'static str, u8> = {
+        let mut m = HashMap::new();
+        m.insert("regular", 0);
+        m.insert("bold", 1);
+        m.insert("faint", 2);
+        m.insert("italic", 3);
+        m.insert("underline", 4);
+        m.insert("blink", 5);
+        m.insert("rapid-blink", 6);
+        m.insert("overline", 53);
+        m
+    };
+}
+
+/// A list of font styles
+#[derive(Default)]
+pub struct FontStyle(Vec<u8>);
+
+impl FontStyle {
+    /// Creates a FontStyle from the yaml
+    ///
+    /// # Panics
+    ///
+    /// Panics if the yaml value is neither a string or
+    /// a yaml array
+    pub fn from_yaml(map: &Hash) -> Self {
+        match map.get(&Yaml::String("font-style".into())) {
+            Some(value) => match value {
+                Yaml::String(s) => Self(vec![ANSI_STYLES[s.as_str()]]),
+                Yaml::Array(array) => {
+                    let mut vec = Vec::with_capacity(array.len());
+                    for item in array {
+                        vec.push(
+                            ANSI_STYLES[item
+                                .as_str()
+                                .expect("font_style should be a string or an array of strings")],
+                        );
+                    }
+                    Self(vec)
+                }
+                _ => panic!("font-style should be a string or an array of strings"),
+            },
+            None => Self::default(),
+        }
+    }
+}
+
+impl Display for FontStyle {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        for style in &self.0 {
+            write!(f, "{};", style)?;
+        }
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod color;
 mod error;
 mod filetypes;
+mod font_style;
 mod theme;
 mod types;
 mod util;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -105,10 +105,7 @@ impl Theme {
             let mut style: String = format!("{font_style}");
             if let Some(foreground) = foreground {
                 let foreground_code = foreground.get_style(ColorType::Foreground, self.color_mode);
-                style.push_str(&format!(
-                    ";{foreground_code}",
-                    foreground_code = foreground_code
-                ));
+                style.push_str(&foreground_code);
             }
 
             if let Some(background) = background {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -105,7 +105,10 @@ impl Theme {
             let mut style: String = format!("{font_style}");
             if let Some(foreground) = foreground {
                 let foreground_code = foreground.get_style(ColorType::Foreground, self.color_mode);
-                style.push_str(&foreground_code);
+                style.push_str(&format!(
+                    ";{foreground_code}",
+                    foreground_code = foreground_code
+                ));
             }
 
             if let Some(background) = background {


### PR DESCRIPTION
This allows multiple `font_style`s to be used, allowing, say, for a bold and italic text. Fixes #49

All previous examples should work, but now you can also specify:

```yaml
font-style:
  - bold
  - underline
```