### PR TITLE
Added Ansi 3-bit Colors

### DIFF
--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -111,6 +111,7 @@ markup:
 programming:
   source:
     actionscript: [.as]
+    ada: [.adb, .ads]
     applescript: [.applescript]
     asp: [.asa]
     awk: [.awk]
@@ -132,6 +133,7 @@ programming:
     go: [.go]
     graphviz: [.dot, .gv]
     groovy: [.groovy, .gvy, .gradle]
+    hack: [.hack]
     haskell: [.hs]
     ipython: [.ipynb]
     java: [.java, .bsh]
@@ -145,6 +147,8 @@ programming:
     lua: [.lua]
     mathematica: [.nb]
     matlab: [.matlab, .m, .mn]
+    mojo: [.mojo]
+    nim: [.nim, .nims, .nimble]
     ocaml: [.ml, .mli]
     pascal: [.pas, .p, .dpr]
     perl: [.pl, .pm, .pod, .t, .cgi]
@@ -155,6 +159,7 @@ programming:
     purescript: [.purs]
     python: [.py]
     r: [.r]
+    raku: [.raku]
     ruby: [.rb]
     rust: [.rs]
     sass: [.sass, .scss]
@@ -247,6 +252,7 @@ programming:
 
     continuous-integration:
       - appveyor.yml
+      - azure-pipelines.yml
       - .cirrus.yml
       - .gitlab-ci.yml
       - .travis.yml
@@ -263,16 +269,19 @@ media:
     - .jpg
     - .jxl
     - .pbm
+    - .pcx
     - .pgm
     - .png
     - .ppm
     - .psd
     - .qoi
     - .svg
+    - .tga
     - .tif
     - .tiff
     - .webp
     - .xcf
+    - .xpm
 
   audio:
     - .aif
@@ -298,6 +307,7 @@ media:
     - .mp4
     - .mpeg
     - .mpg
+    - .ogv
     - .rm
     - .swf
     - .vob
@@ -344,6 +354,7 @@ archives:
   packages:
     - .apk
     - .deb
+    - .msi
     - .rpm
     - .xbps
 

--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -150,12 +150,14 @@ programming:
     perl: [.pl, .pm, .pod, .t, .cgi]
     php: [.php]
     powershell: [.ps1, .psm1, .psd1]
+    prql: [.prql]
     puppet: [.pp, .epp]
     purescript: [.purs]
     python: [.py]
     r: [.r]
     ruby: [.rb]
     rust: [.rs]
+    sass: [.sass, .scss]
     scala: [.scala, .sbt]
     shell: [.sh, .bash, .bashrc, .bash_profile, .zsh, .fish]
     sql: [.sql]
@@ -165,6 +167,7 @@ programming:
     typescript: [.ts, .tsx]
     v: [.v, .vsh]
     viml: [.vim]
+    zig: [.zig]
 
   tooling:
     vcs:
@@ -184,6 +187,7 @@ programming:
         - .ignore
         - .fdignore
         - .rgignore
+        - .tfignore
 
     build:
       cmake:
@@ -253,14 +257,17 @@ media:
     - .bmp
     - .eps
     - .gif
+    - .heif
     - .ico
     - .jpeg
     - .jpg
+    - .jxl
     - .pbm
     - .pgm
     - .png
     - .ppm
     - .psd
+    - .qoi
     - .svg
     - .tif
     - .tiff
@@ -303,6 +310,7 @@ media:
     - .otf
     - .ttf
     - .woff
+    - .woff2
 
 office:
   document:
@@ -378,6 +386,7 @@ executable:
     - .so
     - .a
     - .dll
+    - .dylib
 
   linux:
     - .ko
@@ -442,5 +451,6 @@ unimportant:
     - .pid
     - .swp
     - .tmp
+    - bun.lockb
     - go.sum
     - package-lock.json

--- a/src/color.rs
+++ b/src/color.rs
@@ -20,11 +20,44 @@ impl ColorType {
             ColorType::Background => "48",
         }
     }
+
+    /// Returns `10` if this is `Background`
+    ///
+    /// This is to be added to a foreground ansi 3-bit code
+    /// to allow it to be a background
+    fn bg_addition(self) -> u8 {
+        match self {
+            ColorType::Foreground => 0,
+            ColorType::Background => 10,
+        }
+    }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Color {
     Rgb(u8, u8, u8),
+    Ansi3Bit(Ansi3Bit),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[repr(u8)]
+pub enum Ansi3Bit {
+    Black = 30,
+    Red = 31,
+    Green = 32,
+    Yellow = 33,
+    Blue = 34,
+    Magenta = 35,
+    Cyan = 36,
+    White = 37,
+    BrightBlack = 90,
+    BrightRed = 91,
+    BrightGreen = 92,
+    BrightYellow = 93,
+    BrightBlue = 94,
+    BrightMagenta = 95,
+    BrightCyan = 96,
+    BrightWhite = 97,
 }
 
 impl Color {
@@ -64,6 +97,7 @@ impl Color {
                     code = ansi256_from_rgb((*r, *g, *b))
                 ),
             },
+            Color::Ansi3Bit(color) => format!("{}", *color as u8 + colortype.bg_addition()),
         }
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -105,22 +105,22 @@ impl Color {
 
     fn from_ansi_name(s: &str) -> Result<Color> {
         match s {
-            "black" => Ok(Self::Ansi3Bit(Ansi3Bit::Black)),
-            "red" => Ok(Self::Ansi3Bit(Ansi3Bit::Red)),
-            "green" => Ok(Self::Ansi3Bit(Ansi3Bit::Green)),
-            "yellow" => Ok(Self::Ansi3Bit(Ansi3Bit::Yellow)),
-            "blue" => Ok(Self::Ansi3Bit(Ansi3Bit::Blue)),
-            "magenta" => Ok(Self::Ansi3Bit(Ansi3Bit::Magenta)),
-            "cyan" => Ok(Self::Ansi3Bit(Ansi3Bit::Cyan)),
-            "white" => Ok(Self::Ansi3Bit(Ansi3Bit::White)),
-            "bright_black" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightBlack)),
-            "bright_red" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightRed)),
-            "bright_green" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightGreen)),
-            "bright_yellow" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightYellow)),
-            "bright_blue" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightBlue)),
-            "bright_magenta" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightMagenta)),
-            "bright_cyan" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightCyan)),
-            "bright_white" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightWhite)),
+            "ansi:black" => Ok(Self::Ansi3Bit(Ansi3Bit::Black)),
+            "ansi:red" => Ok(Self::Ansi3Bit(Ansi3Bit::Red)),
+            "ansi:green" => Ok(Self::Ansi3Bit(Ansi3Bit::Green)),
+            "ansi:yellow" => Ok(Self::Ansi3Bit(Ansi3Bit::Yellow)),
+            "ansi:blue" => Ok(Self::Ansi3Bit(Ansi3Bit::Blue)),
+            "ansi:magenta" => Ok(Self::Ansi3Bit(Ansi3Bit::Magenta)),
+            "ansi:cyan" => Ok(Self::Ansi3Bit(Ansi3Bit::Cyan)),
+            "ansi:white" => Ok(Self::Ansi3Bit(Ansi3Bit::White)),
+            "ansi:bright_black" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightBlack)),
+            "ansi:bright_red" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightRed)),
+            "ansi:bright_green" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightGreen)),
+            "ansi:bright_yellow" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightYellow)),
+            "ansi:bright_blue" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightBlue)),
+            "ansi:bright_magenta" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightMagenta)),
+            "ansi:bright_cyan" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightCyan)),
+            "ansi:bright_white" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightWhite)),
             _ => Err(VividError::ColorParseError(s.to_string())),
         }
     }
@@ -192,15 +192,21 @@ mod tests {
 
     #[test]
     fn ansi_3bit() {
-        assert_eq!(Color::Ansi3Bit(Ansi3Bit::Black), "black".parse().unwrap());
-        assert_eq!(Color::Ansi3Bit(Ansi3Bit::Green), "green".parse().unwrap());
+        assert_eq!(
+            Color::Ansi3Bit(Ansi3Bit::Black),
+            "ansi:black".parse().unwrap()
+        );
+        assert_eq!(
+            Color::Ansi3Bit(Ansi3Bit::Green),
+            "ansi:green".parse().unwrap()
+        );
         assert_eq!(
             Color::Ansi3Bit(Ansi3Bit::BrightYellow),
-            "bright_yellow".parse().unwrap()
+            "ansi:bright_yellow".parse().unwrap()
         );
         assert_eq!(
             Color::Ansi3Bit(Ansi3Bit::BrightCyan),
-            "bright_cyan".parse().unwrap()
+            "ansi:bright_cyan".parse().unwrap()
         );
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::error::{Result, VividError};
 use ansi_colours::ansi256_from_rgb;
 
@@ -100,10 +102,41 @@ impl Color {
             Color::Ansi3Bit(color) => format!("{}", *color as u8 + colortype.bg_addition()),
         }
     }
+
+    fn from_ansi_name(s: &str) -> Result<Color> {
+        match s {
+            "black" => Ok(Self::Ansi3Bit(Ansi3Bit::Black)),
+            "red" => Ok(Self::Ansi3Bit(Ansi3Bit::Red)),
+            "green" => Ok(Self::Ansi3Bit(Ansi3Bit::Green)),
+            "yellow" => Ok(Self::Ansi3Bit(Ansi3Bit::Yellow)),
+            "blue" => Ok(Self::Ansi3Bit(Ansi3Bit::Blue)),
+            "magenta" => Ok(Self::Ansi3Bit(Ansi3Bit::Magenta)),
+            "cyan" => Ok(Self::Ansi3Bit(Ansi3Bit::Cyan)),
+            "white" => Ok(Self::Ansi3Bit(Ansi3Bit::White)),
+            "bright_black" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightBlack)),
+            "bright_red" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightRed)),
+            "bright_green" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightGreen)),
+            "bright_yellow" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightYellow)),
+            "bright_blue" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightBlue)),
+            "bright_magenta" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightMagenta)),
+            "bright_cyan" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightCyan)),
+            "bright_white" => Ok(Self::Ansi3Bit(Ansi3Bit::BrightWhite)),
+            _ => Err(VividError::ColorParseError(s.to_string())),
+        }
+    }
+}
+
+impl FromStr for Color {
+    type Err = VividError;
+    fn from_str(s: &str) -> Result<Self> {
+        Color::from_hex_str(s).or(Color::from_ansi_name(s))
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::color::Ansi3Bit;
+
     use super::{Color, ColorMode, ColorType};
 
     #[test]
@@ -155,5 +188,19 @@ mod tests {
 
         let style_24bit = red.get_style(ColorType::Foreground, ColorMode::BitDepth24);
         assert_eq!("38;2;255;0;0", style_24bit);
+    }
+
+    #[test]
+    fn ansi_3bit() {
+        assert_eq!(Color::Ansi3Bit(Ansi3Bit::Black), "black".parse().unwrap());
+        assert_eq!(Color::Ansi3Bit(Ansi3Bit::Green), "green".parse().unwrap());
+        assert_eq!(
+            Color::Ansi3Bit(Ansi3Bit::BrightYellow),
+            "bright_yellow".parse().unwrap()
+        );
+        assert_eq!(
+            Color::Ansi3Bit(Ansi3Bit::BrightCyan),
+            "bright_cyan".parse().unwrap()
+        );
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -51,7 +51,7 @@ impl Theme {
                 for (key, value) in map {
                     match (key, value) {
                         (Yaml::String(key), Yaml::String(value)) => {
-                            colors.insert(key.clone(), Color::from_hex_str(value)?);
+                            colors.insert(key.clone(), value.parse()?);
                         }
                         _ => return Err(VividError::UnexpectedYamlType),
                     }
@@ -71,7 +71,7 @@ impl Theme {
         self.colors
             .get(color_str)
             .cloned()
-            .or_else(|| Color::from_hex_str(color_str).ok())
+            .or_else(|| color_str.parse().ok())
             .ok_or_else(|| VividError::UnknownColor(color_str.to_string()))
     }
 


### PR DESCRIPTION
This patch allows the use of the colours: `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, `bright_black`, `bright_red`, `bright_green`, `bright_yellow`, `bright_blue`, `bright_magenta`, `bright_cyan`, `bright_white`, in any field which accepts a colour.  These will then be parsed as their [Ansi 3/4 bit equivalents](https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit).  I believe this makes a good addition to the program as some people (myself included), will prefer just to use the colours they've already defined in their terminal.  Further, this works better with some tools (e.g. `ranger`) which only support Ansi 3/4 or 256-colour, in which case the ansi 3/4 actually provides more accurate colours (given it is not quantized to the 256 palette, but rather to the terminals.)