### PR TITLE
Update filetypes.yml

### DIFF
--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -175,7 +175,7 @@ programming:
     rust: [.rs]
     sass: [.sass, .scss]
     scala: [.scala, .sbt]
-    shell: [.sh, .bash, , .nu, .bashrc, .bash_profile, .zsh, .fish]
+    shell: [.sh, .bash, .nu, .bashrc, .bash_profile, .zsh, .fish]
     sql: [.sql]
     swift: [.swift]
     tablegen: [.td]


### PR DESCRIPTION
fix a typo which generate the error:
    
Error: while parsing a node, did not find expected node content at line 178 column 25