### PR TITLE
Add "c" command to generate escape sequences for a given style

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,7 @@ pub enum VividError {
     EmptyThemeFile,
     CouldNotFindStyleFor(String),
     UnknownColor(String),
+    NoCategoryProvided,
     InvalidFileName(String),
 }
 
@@ -46,6 +47,7 @@ impl Display for VividError {
                 write!(fmt, "Could not find style for category '{}'", category)
             }
             VividError::UnknownColor(color) => write!(fmt, "Unknown color '{}'", color),
+            VividError::NoCategoryProvided => write!(fmt, "No category provided."),
             VividError::InvalidFileName(file_name) => {
                 write!(fmt, "Invalid file name '{}'", file_name)
             }


### PR DESCRIPTION
This adds a "c" command which will generate the escape sequence for a style defined in the given theme category. This is allows me to do automate colors for my prompt in .bashrc/.zshrc, for example:

```bash
export VIVID_THEME="catppuccin-mocha"
icon_style="$(vivid c programming.source)";
dir_style="$(vivid c core.directory)";
reset="$(vivid c reset)";

[[ -z "$ICON" ]] && ICON=""

PROMPT="%{${icon_style}%}${ICON} "
PROMPT+=" %{${dir_style}%}%c%{$reset%} "
export PROMPT
export CLICOLOR=1
export LS_COLORS="$(vivid generate)"
```