### PR TITLE
Add .ers (rust-script) extension

### DIFF
--- a/config/filetypes.yml
+++ b/config/filetypes.yml
@@ -176,7 +176,7 @@ programming:
     r: [.r]
     raku: [.raku]
     ruby: [.rb]
-    rust: [.rs]
+    rust: [.ers, .rs]
     sass: [.sass, .scss]
     scala: [.scala, .sbt]
     shell: [.sh, .bash, .nu, .bashrc, .bash_profile, .zsh, .fish]


### PR DESCRIPTION
This adds handling of `.ers` files, which is basically a Rust source file with a shebang to be directly executable.

See https://rust-script.org/#executable-scripts

`rust-script` is currently the de-facto implementation of https://rust-lang.github.io/rfcs/3424-cargo-script.html
