### PR TITLE
Add renovate configuration

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:recommended"
+    ],
+    "labels": [
+        "dependencies"
+    ],
+    "lockFileMaintenance": {
+        "automerge": true,
+        "enabled": true
+    },
+    "schedule": ["* 0 * * 0"],
+    "packageRules": [
+        {
+            "matchManagers": [
+                "github-actions"
+            ],
+            "groupName": "github-actions",
+            "automerge": false,
+            "schedule": ["* 0 1 * *"]
+        },
+        {
+            "matchUpdateTypes": [
+                "major"
+            ],
+            "automerge": false
+        },
+        {
+            "automerge": true,
+            "matchUpdateTypes": [
+                "patch",
+                "pin",
+                "digest",
+                "minor"
+            ]
+        }
+    ],
+    "separateMinorPatch": false,
+    "prHourlyLimit": 0,
+    "prConcurrentLimit": 0
+}


### PR DESCRIPTION
[Renovate](https://github.com/renovatebot/renovate) is a bot that manages dependencies and updates, like dependabot, but better (imho). This PR adds a configuration file that will be used should we add renovate to this repo.

- General updates run weekly on Sunday, while GHA updates are grouped and updated monthly.
- Minor, patch, pin, digest updates are automatically merged. Major version updates require manual approval.
