### PR TITLE
pin digests in github actions

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -18,7 +18,8 @@
             ],
             "groupName": "github-actions",
             "automerge": false,
-            "schedule": ["* 0 1 * *"]
+            "schedule": ["* 0 1 * *"],
+            "pinDigests": true
         },
         {
             "matchUpdateTypes": [


### PR DESCRIPTION
- Update renovate config to pin CI actions to digests. Since tags are mutable, this is the most verifiable version pinning option, made easy to update thanks to the bot.
