### PR TITLE
Reduce renovate runs to once per month

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -10,7 +10,7 @@
         "automerge": true,
         "enabled": true
     },
-    "schedule": ["* 0 * * 0"],
+    "schedule": ["* * 1 * *"],
     "packageRules": [
         {
             "matchManagers": [


### PR DESCRIPTION
Renovate seems to be working well enough. Let's reduce the notification & git log spam from dependency updates.

`* * 1 * *` according to [crontab.guru](https://crontab.guru) means "At every minute on day-of-month 1." So one day per month.
