### PR TITLE
Make italic styles opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ option when running `vivid`. This will generate interpolated 8-bit colors:
 export LS_COLORS="$(vivid -m 8-bit generate molokai)"
 ```
 
+### Italic font styles
+
+Italic styles are disabled by default. Enable them with the `--italic` option:
+
+``` bash
+export LS_COLORS="$(vivid --italic generate molokai)"
+```
+
 ### Re-using your terminal's color theme
 
 To match your terminal's existing color theme, you can use the `ansi` theme, which uses your terminal theme's 16-color ANSI palette. This way colors adapt to your terminal theme, such as when you switch between light and dark mode.

--- a/src/font_style.rs
+++ b/src/font_style.rs
@@ -33,10 +33,10 @@ impl FontStyle {
     ///
     /// Panics if the yaml value is neither a string or
     /// a yaml array
-    pub fn from_yaml(map: &Hash) -> Self {
-        match map.get(&Yaml::String("font-style".into())) {
+    pub fn from_yaml(map: &Hash, use_italic: bool) -> Self {
+        let mut styles = match map.get(&Yaml::String("font-style".into())) {
             Some(value) => match value {
-                Yaml::String(s) => Self(vec![ANSI_STYLES[s.as_str()]]),
+                Yaml::String(s) => vec![ANSI_STYLES[s.as_str()]],
                 Yaml::Array(array) => {
                     let mut vec = Vec::with_capacity(array.len());
                     for item in array {
@@ -46,12 +46,19 @@ impl FontStyle {
                                 .expect("font_style should be a string or an array of strings")],
                         );
                     }
-                    Self(vec)
+                    vec
                 }
                 _ => panic!("font-style should be a string or an array of strings"),
             },
-            None => Self(vec![0]),
+            None => vec![0],
+        };
+        if !use_italic {
+            styles.retain(|style| *style != 3);
         }
+        if styles.is_empty() {
+            styles.push(0);
+        }
+        Self(styles)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,6 +146,13 @@ fn cli() -> clap::Command {
                 .value_name("path")
                 .help("Path to filetypes database (filetypes.yml)"),
         )
+        .arg(
+            Arg::new("italic")
+                .long("italic")
+                .action(ArgAction::SetTrue)
+                .global(true)
+                .help("Use italic font styles"),
+        )
         .subcommand(
             Command::new("generate")
                 .about("Generate a LS_COLORS expression")
@@ -171,6 +178,7 @@ fn run() -> Result<()> {
         Some("8-bit") => ColorMode::BitDepth8,
         _ => ColorMode::BitDepth24,
     };
+    let use_italic = matches.get_flag("italic");
 
     let basedirs = etcetera::choose_base_strategy().expect("Could not get home directory");
     let user_config_path = basedirs.config_dir().join("vivid");
@@ -186,7 +194,7 @@ fn run() -> Result<()> {
         let mut mapping = filetypes
             .mapping
             .iter()
-            .map(|(filetype, category)| (filetype, theme.get_style(category)))
+            .map(|(filetype, category)| (filetype, theme.get_style(category, use_italic)))
             .map(|(filetype, style)| style.map(|style| (filetype, style)))
             .collect::<Result<Vec<_>>>()?;
 
@@ -207,7 +215,9 @@ fn run() -> Result<()> {
         pairs.sort_by_key(|(_, category)| *category);
 
         for (entry, category) in pairs {
-            let ansi_code = theme.get_style(category).unwrap_or_else(|_| "0".into());
+            let ansi_code = theme
+                .get_style(category, use_italic)
+                .unwrap_or_else(|_| "0".into());
             writeln!(
                 stdout_lock,
                 "{}: \x1b[{}m{}\x1b[0m",

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -59,7 +59,7 @@ impl Theme {
             .ok_or_else(|| VividError::UnknownColor(color_str.to_string()))
     }
 
-    pub fn get_style(&self, category: CategoryRef) -> Result<String> {
+    pub fn get_style(&self, category: CategoryRef, use_italic: bool) -> Result<String> {
         if category.is_empty() {
             // TODO: use a non-empty collection data type to avoid this
             panic!("category should not be empty");
@@ -88,7 +88,7 @@ impl Theme {
         }
 
         if let Yaml::Hash(map) = item {
-            let font_style = FontStyle::from_yaml(map);
+            let font_style = FontStyle::from_yaml(map, use_italic);
 
             let foreground = map
                 .get(&Yaml::String("foreground".into()))
@@ -149,20 +149,33 @@ mod tests {
                     foreground: '000000'
 
                 t3:
-                    font-style: bold",
+                    font-style: bold
+
+                t4:
+                    font-style: [bold, italic]
+
+                t5:
+                    font-style: italic",
             ColorMode::BitDepth24,
         )
         .unwrap();
 
-        let style1 = theme.get_style(&["foo".into(), "bar".into()]).unwrap();
+        let style1 = theme
+            .get_style(&["foo".into(), "bar".into()], false)
+            .unwrap();
         assert_eq!("0;38;2;0;255;127", style1);
 
         let style2 = theme
-            .get_style(&["c1".into(), "c2".into(), "c3".into()])
+            .get_style(&["c1".into(), "c2".into(), "c3".into()], false)
             .unwrap();
         assert_eq!("0;38;2;0;0;0", style2);
 
-        let style3 = theme.get_style(&["t3".into()]).unwrap();
+        let style3 = theme.get_style(&["t3".into()], false).unwrap();
         assert_eq!("1", style3);
+
+        assert_eq!("1", theme.get_style(&["t4".into()], false).unwrap());
+        assert_eq!("1;3", theme.get_style(&["t4".into()], true).unwrap());
+        assert_eq!("0", theme.get_style(&["t5".into()], false).unwrap());
+        assert_eq!("3", theme.get_style(&["t5".into()], true).unwrap());
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,5 +1,20 @@
 use assert_cmd::Command;
 
+fn generated_style(args: &[&str], key: &str) -> String {
+    let output = Command::cargo_bin("vivid")
+        .unwrap()
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    String::from_utf8(output.stdout)
+        .unwrap()
+        .trim()
+        .split(':')
+        .find_map(|entry| entry.strip_prefix(&format!("{key}=")).map(str::to_owned))
+        .unwrap()
+}
+
 #[test]
 fn can_call_vivid_generate_for_all_themes() {
     let themes_dir = std::fs::read_dir("themes").unwrap();
@@ -16,4 +31,17 @@ fn can_call_vivid_generate_for_all_themes() {
 
         cmd.arg("generate").arg(theme_name).assert().success();
     }
+}
+
+#[test]
+fn italic_styles_require_flag() {
+    assert_eq!("0;36", generated_style(&["generate", "ansi"], "ln"));
+    assert_eq!(
+        "3;36",
+        generated_style(&["--italic", "generate", "ansi"], "ln")
+    );
+    assert_eq!(
+        "3;36",
+        generated_style(&["generate", "ansi", "--italic"], "ln")
+    );
 }


### PR DESCRIPTION
Closes #6.

This makes italic styles opt-in with a global `--italic` flag. It applies to both `generate` and `preview`.

Tested with `cargo test --locked`, `cargo fmt -- --check`, and `cargo clippy --locked --all-targets`.
