### PR TITLE
ci: complete native platform release matrix

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -76,7 +76,7 @@ jobs:
           - { target: i686-pc-windows-msvc        , os: windows-latest                 }
           - { target: i686-unknown-linux-gnu      , os: ubuntu-latest, use-cross: true }
           - { target: i686-unknown-linux-musl     , os: ubuntu-latest, use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-15-intel                 }
+          - { target: x86_64-apple-darwin         , os: macos-15                       }
           - { target: aarch64-apple-darwin        , os: macos-latest                   }
           - { target: x86_64-pc-windows-gnu       , os: windows-latest                 }
           - { target: x86_64-pc-windows-msvc      , os: windows-latest                 }

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -76,10 +76,11 @@ jobs:
           - { target: i686-pc-windows-msvc        , os: windows-latest                 }
           - { target: i686-unknown-linux-gnu      , os: ubuntu-latest, use-cross: true }
           - { target: i686-unknown-linux-musl     , os: ubuntu-latest, use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-15                       }
+          - { target: x86_64-apple-darwin         , os: macos-15-intel                 }
           - { target: aarch64-apple-darwin        , os: macos-latest                   }
           - { target: x86_64-pc-windows-gnu       , os: windows-latest                 }
           - { target: x86_64-pc-windows-msvc      , os: windows-latest                 }
+          - { target: aarch64-pc-windows-msvc     , os: windows-11-arm                }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-latest, use-cross: true }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-latest, use-cross: true }
     env:


### PR DESCRIPTION
## Summary

- add aarch64-pc-windows-msvc on the native windows-11-arm runner
- pin the Intel macOS release to macos-15-intel

## Validation

The complete workflow passed in my fork. The Windows ARM64 job built, ran tests, packaged, and uploaded vivid-v0.11.1-aarch64-pc-windows-msvc.zip:
https://github.com/meop/vivid/actions/runs/31942874710

## Disclosure

This change was prepared with assistance from OpenAI Codex. I reviewed the resulting diff and validated it through the linked GitHub Actions run.