### PR TITLE
Add 'include: default' to extend the bundled filetypes database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Changes
 
+- A custom `filetypes.yml` can now start from the bundled defaults with `include: default` and only list the entries it wants to add or override, see #59 (@ChrisJr404)
+
 
 ## New filetypes
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ export LS_COLORS="$(vivid generate ansi)"
 Custom [`filetypes.yml` databases](config/filetypes.yml) can be placed in `/usr/share/vivid`, `$HOME/.config/vivid`, or `$XDG_CONFIG_HOME/vivid` on POSIX systems,
 or in `%APPDATA%\vivid` on Windows systems.
 
+If you only want to tweak a few entries instead of maintaining a full copy of the database, start your `filetypes.yml` with `include: default`. The bundled defaults are loaded first, and the remaining entries are applied on top of them as additions or overrides:
+
+```yaml
+include: default
+
+# Treat `.m` as Objective-C instead of the default (Matlab):
+programming:
+  source:
+    objective_c: [.m]
+```
+
 Custom color themes go into a `themes` subfolder, respectively.  You can also specify an explicit path to your custom theme: `vivid generate path/to/my_theme.yml`.
 As a starting point, you can use one of the [bundled themes](themes/).
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,7 @@ pub enum VividError {
     UnexpectedYamlType,
     ColorParseError(String),
     DuplicateFileType(String),
+    UnknownInclude(String),
     CouldNotLoadDatabaseFrom(String),
     CouldNotFindTheme(String),
     CouldNotLoadTheme(String),
@@ -32,6 +33,11 @@ impl Display for VividError {
                 write!(fmt, "Could not parse color string '{}'.", color_str)
             }
             VividError::DuplicateFileType(ft) => write!(fmt, "Duplicate file type '{}'.", ft),
+            VividError::UnknownInclude(target) => write!(
+                fmt,
+                "Unknown 'include' target '{}'. Only 'default' is supported.",
+                target
+            ),
             VividError::CouldNotLoadDatabaseFrom(path) => {
                 write!(fmt, "Could not load filetypes database from '{}'.", path)
             }

--- a/src/filetypes.rs
+++ b/src/filetypes.rs
@@ -36,7 +36,33 @@ impl FileTypes {
         let docs = YamlLoader::load_from_str(contents)?;
         let doc = &docs[0];
 
+        // A database can start from the bundled defaults by adding an `include: default`
+        // key at the top level. The remaining entries are then treated as additions or
+        // overrides on top of those defaults, so users only need to list what they want
+        // to change instead of copying the whole database.
+        if let Yaml::Hash(hash) = doc {
+            let include_key = Yaml::String("include".to_string());
+            if let Some(include) = hash.get(&include_key) {
+                let mut base = Self::included_base(include)?;
+
+                let mut overrides = hash.clone();
+                overrides.remove(&include_key);
+                let extra = Self::get_mapping(&Yaml::Hash(overrides), &vec![])?;
+                base.mapping.extend(extra.mapping);
+
+                return Ok(base);
+            }
+        }
+
         Self::get_mapping(doc, &vec![])
+    }
+
+    fn included_base(include: &Yaml) -> Result<FileTypes> {
+        match include {
+            Yaml::String(name) if name == "default" => Self::from_embedded(),
+            Yaml::String(name) => Err(VividError::UnknownInclude(name.clone())),
+            _ => Err(VividError::UnexpectedYamlType),
+        }
     }
 
     fn get_code(filetype: &str) -> String {
@@ -121,5 +147,61 @@ mod tests {
             vec!["bar".to_string(), "baz".to_string()],
             ft.mapping["*.ext3"]
         );
+    }
+
+    #[test]
+    fn include_default_overrides_existing_extension() {
+        let ft = FileTypes::from_string(
+            "
+                include: default
+
+                programming:
+                  source:
+                    objective_c: [.m]
+            ",
+        )
+        .unwrap();
+
+        // `.m` now resolves to Objective-C instead of the default Matlab mapping.
+        assert_eq!(
+            vec![
+                "programming".to_string(),
+                "source".to_string(),
+                "objective_c".to_string()
+            ],
+            ft.mapping["*.m"]
+        );
+
+        // Extensions that were not touched keep their default categories.
+        assert_eq!(
+            vec![
+                "programming".to_string(),
+                "source".to_string(),
+                "rust".to_string()
+            ],
+            ft.mapping["*.rs"]
+        );
+    }
+
+    #[test]
+    fn include_default_adds_new_extension() {
+        let ft = FileTypes::from_string(
+            "
+                include: default
+
+                programming:
+                  source:
+                    objective_c: [.mm]
+            ",
+        )
+        .unwrap();
+
+        assert!(ft.mapping.contains_key("*.mm"));
+        assert!(ft.mapping.contains_key("*.rs"));
+    }
+
+    #[test]
+    fn unknown_include_target_is_an_error() {
+        assert!(FileTypes::from_string("include: nonsense\n").is_err());
     }
 }


### PR DESCRIPTION
Closes #59.

Right now, tweaking a single extension means copying the whole `filetypes.yml` and keeping it in sync with every release. This adds an `include: default` key so a custom database can start from the bundled defaults and only list the entries you want to add or override. It's the `include` variant you sketched out in that thread:

```yaml
include: default

programming:
  source:
    objective_c: [.m]
```

The defaults are loaded first, then the remaining top-level entries are merged on top, so later entries win. Anything you don't mention keeps its default category, which for the `.m` case means Objective-C files stay under `programming.source` and pick up the same styling. An unknown include target (anything other than `default`) is reported as an error.

Added unit tests for the override and add cases plus the error path, and documented it in the README. Happy to switch to the `overrides:` block instead if you'd prefer that shape.