### PR TITLE
docs: fix Homebrew formula and Arch Linux package links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ sudo dpkg -i vivid_0.10.1_amd64.deb
 
 ### On Arch Linux
 
-You can install `vivid` from [the official package repository](https://www.archlinux.org/packages/community/x86_64/vivid/):
+You can install `vivid` from [the official package repository](https://archlinux.org/packages/extra/x86_64/vivid/):
 
 ``` bash
 pacman -S vivid
@@ -119,7 +119,7 @@ pkg install vivid
 
 ### On macOS
 
-You can install `vivid` from [Homebrew](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/vivid.rb):
+You can install `vivid` from [Homebrew](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/v/vivid.rb):
 
 ``` bash
 brew install vivid


### PR DESCRIPTION
Two README links currently 404:

- Homebrew: homebrew-core moved formulas into per-letter subdirectories, so the formula lives at `Formula/v/vivid.rb` now
- Arch Linux: the package moved from `[community]` to `[extra]`, and `www.archlinux.org` package pages are retired

Both replacement URLs verified to return HTTP 200.
